### PR TITLE
Fix repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "xterm.js addon for ensuring webfonts load",
   "main": "index.js",
   "author": "Vincent Woo <vincent@coderpad.io>",
-  "repository": "CoderPad/xterm-webfont",
+  "repository": "https://github.com/CoderPad/xterm-webfont",
   "homepage": "https://github.com/CoderPad/xterm-webfont",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Doesn't show up on npmjs.com without this.